### PR TITLE
Switch name to Public Benefits Portfolio

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ This repository houses a microsite about 18F's portfolios. We use the [U.S. Web 
 
 To contribute, you'll just need a GitHub account. After that, check out [CONTRIBUTING.MD](./CONTRIBUTING.MD) for some more details.
 
-For Human Services Portfolio content, check out [🔒 our governance/approval process](https://docs.google.com/document/d/18JpJs6HDY624atN8RcL1vgTCkLOfd2_T7C-2BFEMPQI/edit#heading=h.w7bz3n3oh45o). The is no Official Editor as of yet, but you can hop into either the #portfolio-site or #portfolio-human-srvcs channel on Slack, or tag/DM @stvnrlly.
+For Public Benefits Portfolio content, check out [🔒 our governance/approval process](https://docs.google.com/document/d/18JpJs6HDY624atN8RcL1vgTCkLOfd2_T7C-2BFEMPQI/edit#heading=h.w7bz3n3oh45o). The is no Official Editor as of yet, but you can hop into either the #portfolio-site or #portfolio-human-srvcs channel on Slack, or tag/DM @stvnrlly.
 
 ### Adding a portfolio project
 

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,17 +1,17 @@
 navbar:
 - text: Public Benefits
-  permalink: /human-services/
+  permalink: /public-benefits/
 - text: National Security & Intelligence
   permalink: /national-security-intelligence/
 
 drawer:
   - text: Public Benefits
-    permalink: /human-services/
+    permalink: /public-benefits/
   - text: National Security & Intelligence
     permalink: /national-security-intelligence/
 
 footer:
   - text: Public Benefits
-    permalink: /human-services/
+    permalink: /public-benefits/
   - text: National Security & Intelligence
     permalink: /national-security-intelligence/

--- a/_data/navigation.yml
+++ b/_data/navigation.yml
@@ -1,17 +1,17 @@
 navbar:
-- text: Human Services
+- text: Public Benefits
   permalink: /human-services/
 - text: National Security & Intelligence
   permalink: /national-security-intelligence/
 
 drawer:
-  - text: Human Services
+  - text: Public Benefits
     permalink: /human-services/
   - text: National Security & Intelligence
     permalink: /national-security-intelligence/
 
 footer:
-  - text: Human Services
+  - text: Public Benefits
     permalink: /human-services/
   - text: National Security & Intelligence
     permalink: /national-security-intelligence/

--- a/_includes/navigation/footer.html
+++ b/_includes/navigation/footer.html
@@ -6,7 +6,7 @@
             <h3 class="usa-footer__primary-link">Portfolios</h3>
             <ul class="add-list-reset">
               <li>
-                <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/human-services/">Human Services</a>
+                <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/public-benefits/">Public Benefits</a>
               </li>
               <li>
                <a class="usa-footer__secondary-link" href="{{ site.baseurl }}/national-security-intelligence/">National Security & Intelligence</a>

--- a/_portfolios/human-services.md
+++ b/_portfolios/human-services.md
@@ -1,9 +1,11 @@
 ---
-name: Human Services Portfolio
+name: Public Benefits Portfolio
 heading: We partner with agencies to enable human-centered, digitally-assisted public benefits programs.
 subheading:
 #permalink: /portfolios/human-services/
-permalink: /human-services/
+permalink: /public-benefits/
+redirect_from:
+  - /human-services/
 
 # NOTE: if adding a new partner, make sure that they exist in _data/agencies.yml
 partners:

--- a/_portfolios_projects/cms-eapd.md
+++ b/_portfolios_projects/cms-eapd.md
@@ -17,7 +17,7 @@ project_url:
 learn_more:
 product_clients:
 resources:
-portfolio: Human Services
+portfolio: Public Benefits
 featured: true
 ---
 

--- a/_portfolios_projects/hs-apis-buy.md
+++ b/_portfolios_projects/hs-apis-buy.md
@@ -3,7 +3,7 @@ agency: 10x
 title: Procurement resources for agencies
 permalink: /projects/eligibility-apis/procurement-resources/
 layout: hs-apis-page
-portfolio: Human Services
+portfolio: Public Benefits
 featured: false
 subtitle: Procurement resources for agencies
 links:

--- a/_portfolios_projects/hs-apis-calc.md
+++ b/_portfolios_projects/hs-apis-calc.md
@@ -3,7 +3,7 @@ agency: 10x
 title: Reusable SNAP API and calculator
 permalink: /projects/eligibility-apis/reusable-snap-api/
 layout: hs-apis-page
-portfolio: Human Services
+portfolio: Public Benefits
 featured: false
 subtitle: Reusable SNAP API prototype and calculator
 links:

--- a/_portfolios_projects/hs-apis-home.md
+++ b/_portfolios_projects/hs-apis-home.md
@@ -3,7 +3,7 @@ agency: 10x
 title: Eligibility APIs Initiative
 permalink: /projects/eligibility-apis/
 layout: hs-apis-page
-portfolio: Human Services
+portfolio: Public Benefits
 featured: false
 subtitle: Background
 excerpt: Prototyping tools to help agencies smoothly update their benefits systems as needs change.

--- a/_portfolios_projects/ohs-tta.md
+++ b/_portfolios_projects/ohs-tta.md
@@ -1,6 +1,6 @@
 ---
 class: project-detail
-portfolio: Human Services
+portfolio: Public Benefits
 short_name: Office of Head Start TTA Data
 project_name: Training and Technical Assistance (TTA) Data Platform
 agency: Administration for Children and Families

--- a/_portfolios_projects/samhsa.md
+++ b/_portfolios_projects/samhsa.md
@@ -1,6 +1,6 @@
 ---
 class: project-detail
-portfolio: Human Services
+portfolio: Public Benefits
 short_name: FindTreatment.gov
 project_name: Redesigning a resource site to better serve people in crisis
 partner: Substance Abuse and Mental Health Services Administration

--- a/_portfolios_projects/usda-fns.md
+++ b/_portfolios_projects/usda-fns.md
@@ -17,7 +17,7 @@ project_url:
 learn_more:
 product_clients:
 resources:
-portfolio: Human Services
+portfolio: Public Benefits
 featured: true
 ---
 

--- a/_portfolios_projects/vermont-iee.md
+++ b/_portfolios_projects/vermont-iee.md
@@ -17,7 +17,7 @@ project_url:
 learn_more:
 product_clients:
 resources:
-portfolio: Human Services
+portfolio: Public Benefits
 featured: true
 ---
 

--- a/pages/index.html
+++ b/pages/index.html
@@ -16,7 +16,7 @@ title: Home
   <div class="grid-container">
     <div class="flex-landing-portfolios">
       <div class="col">
-        <a href="{{ site.baseurl }}/human-services" class="usa-button usa-button-fancy">
+        <a href="{{ site.baseurl }}/public-benefits" class="usa-button usa-button-fancy">
           <div class="flex-landing-button">
             <div class="flex-three-fourths fancy-button-text">Public Benefits Portfolio</div>
             <div class="flex-one-fourth fancy-button-icon">

--- a/pages/index.html
+++ b/pages/index.html
@@ -18,7 +18,7 @@ title: Home
       <div class="col">
         <a href="{{ site.baseurl }}/human-services" class="usa-button usa-button-fancy">
           <div class="flex-landing-button">
-            <div class="flex-three-fourths fancy-button-text">Human Services Portfolio</div>
+            <div class="flex-three-fourths fancy-button-text">Public Benefits Portfolio</div>
             <div class="flex-one-fourth fancy-button-icon">
               <svg role="img" aria-hidden="true" width="50px" viewBox="0 0 40 40" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
                 <g stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" stroke-linecap="round" stroke-linejoin="round">


### PR DESCRIPTION
Yep, switches to the new name. Doesn't touch the Eligibility APIs content, but that's easy to add.

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/portfolios/new-hs-name/)

I've added a redirect for at least the main portfolio page, but need to check whether that catches sub-pages.