### PR TITLE
fix redirect w/ correct site.url (remove 2nd one)

### DIFF
--- a/_config.yml
+++ b/_config.yml
@@ -5,7 +5,6 @@ description: "As 18F teams continue to work with agencies that share a common mi
 github_repo: https://github.com/18F/portfolios/blob/release
 baseurl: "" # the subpath of your site, e.g. /blog
 permalink: pretty
-url: "https://18f.gsa.gov" # the base hostname & protocol for your sites
 localhost: "localhost:4000"
 env: "production"
 logo: /assets/img/logos/18F-Logo-Bright-S.png


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>

Fixes issue(s): redirect broken (404s going to 18f main site)

[![CircleCI](https://circleci.com/gh/18F/portfolios/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/portfolios/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/portfolios/fix-redirects/)

Changes proposed in this pull request:
- Remove 2nd `site.url` value in `config.yml` that was resetting the value to the 18f.gsa.gov site.


/cc @stvnrlly 
