### PR TITLE
add portfolio-permalink to project pages so navigation works

### DIFF
--- a/_portfolios_projects/afmc.md
+++ b/_portfolios_projects/afmc.md
@@ -18,6 +18,7 @@ learn_more:
 product_clients:
 resources:
 portfolio: National Security and Intelligence
+portfolio-permalink: /national-security-intelligence/
 featured: true
 ---
 

--- a/_portfolios_projects/alaska-dhss.md
+++ b/_portfolios_projects/alaska-dhss.md
@@ -4,6 +4,8 @@ title: Modernizing access to healthcare
 subtitle: Modernizing public benefit eligibility systems
 layout: portfolio-project-page
 permalink: /projects/alaska-dhss/
+portfolio: State & Local
+portfolio-permalink: /state-local/
 excerpt: Introducing modern digital methods to the State of Alaska’s eligibility system modernization project.
 image: /assets/img/projects/alaska-flag.png
 image_accessibility: Alaska state flag. The flag consists of eight gold stars, forming the Big Dipper and Polaris, on a dark blue field.

--- a/_portfolios_projects/dtmo.md
+++ b/_portfolios_projects/dtmo.md
@@ -18,6 +18,7 @@ learn_more:
 product_clients:
 resources:
 portfolio: National Security and Intelligence
+portfolio-permalink: /national-security-intelligence/
 featured: true
 ---
 

--- a/_portfolios_projects/geoint.md
+++ b/_portfolios_projects/geoint.md
@@ -18,6 +18,7 @@ learn_more:
 product_clients:
 resources:
 portfolio: National Security and Intelligence
+portfolio-permalink: /national-security-intelligence/
 featured: true
 ---
 

--- a/_portfolios_projects/hs-apis-buy.md
+++ b/_portfolios_projects/hs-apis-buy.md
@@ -4,6 +4,7 @@ title: Procurement resources for agencies
 permalink: /projects/eligibility-apis/procurement-resources/
 layout: hs-apis-page
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: false
 subtitle: Procurement resources for agencies
 links:

--- a/_portfolios_projects/hs-apis-calc.md
+++ b/_portfolios_projects/hs-apis-calc.md
@@ -4,6 +4,7 @@ title: Reusable SNAP API and calculator
 permalink: /projects/eligibility-apis/reusable-snap-api/
 layout: hs-apis-page
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: false
 subtitle: Reusable SNAP API prototype and calculator
 links:

--- a/_portfolios_projects/hs-apis-home.md
+++ b/_portfolios_projects/hs-apis-home.md
@@ -4,6 +4,7 @@ title: Eligibility APIs Initiative
 permalink: /projects/eligibility-apis/
 layout: hs-apis-page
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: false
 subtitle: Background
 excerpt: Prototyping tools to help agencies smoothly update their benefits systems as needs change.

--- a/_portfolios_projects/imls.md
+++ b/_portfolios_projects/imls.md
@@ -5,6 +5,7 @@ permalink: /projects/survey-modernization/
 layout: apis
 project: API-driven Survey Modernization
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: false
 subtitle: Background
 excerpt: Merging real-time data with annual process for survey modernization through modularization and APIs.

--- a/_portfolios_projects/ohs-tta.md
+++ b/_portfolios_projects/ohs-tta.md
@@ -1,6 +1,7 @@
 ---
 class: project-detail
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 short_name: Office of Head Start TTA Data
 project_name: Training and Technical Assistance (TTA) Data Platform
 agency: Administration for Children and Families

--- a/_portfolios_projects/pomd.md
+++ b/_portfolios_projects/pomd.md
@@ -5,6 +5,7 @@ permalink: /projects/product-ownership/
 layout: apis
 project: A First Course on Product Ownership
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: false
 subtitle: Background
 excerpt: A reusable, scalable course for building team cohesion and product ownership skills.

--- a/_portfolios_projects/samhsa.md
+++ b/_portfolios_projects/samhsa.md
@@ -1,6 +1,7 @@
 ---
 class: project-detail
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 short_name: FindTreatment.gov
 project_name: Redesigning a resource site to better serve people in crisis
 partner: Substance Abuse and Mental Health Services Administration

--- a/_portfolios_projects/usda-fns.md
+++ b/_portfolios_projects/usda-fns.md
@@ -18,6 +18,7 @@ learn_more:
 product_clients:
 resources:
 portfolio: Public Benefits
+portfolio-permalink: /public-benefits/
 featured: true
 ---
 

--- a/_portfolios_projects/vermont-iee.md
+++ b/_portfolios_projects/vermont-iee.md
@@ -17,7 +17,8 @@ project_url:
 learn_more:
 product_clients:
 resources:
-portfolio: Public Benefits
+portfolio: State & Local
+portfolio-permalink: /state-local/
 featured: true
 ---
 


### PR DESCRIPTION
[![CircleCI](https://circleci.com/gh/18F/portfolios/tree/BRANCH_NAME.svg?style=svg)](https://circleci.com/gh/18F/portfolios/tree/BRANCH_NAME)

[:sunglasses: PREVIEW](https://federalist-proxy.app.cloud.gov/preview/18f/portfolios/BRANCH_NAME/)

[Preview README for this branch](https://github.com/18F/portfolios/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- Add `portfolio-permalink` to project pages so navigation to the original Portfolio page works.
- Add a Portfolio for new State & Local page

Now it looks like this: 

![Screen Shot 2021-06-22 at 1 16 14 PM](https://user-images.githubusercontent.com/10510566/122970580-1b18e380-d35c-11eb-9b19-a8e7143c2329.png)

Checklist:
- [x ] All images being added have been optimized **_--> [learn more](https://18f.gsa.gov/styleguide/images) about how to optimize images <--_**

/cc @stvnrlly 
