### PR TITLE
remove link to Vermont page until content is ready

### DIFF
--- a/_portfolios/state-local.md
+++ b/_portfolios/state-local.md
@@ -120,7 +120,7 @@ Longer-term (3-12 month) agile and user-centered engagements, geared toward lega
     {% include card-project.html
        project='alaska-dhss'
     %}
-    {% include card-project.html
+    {% include card-project-nolink.html
        project='vermont-iee'
     %}
     </div>


### PR DESCRIPTION
Fixes issue(s) reported in Slack by @ayushi-roy (thanks for spotting it). Vermont content was placeholder, but was unlinked until recently. Adding the link from the card to the page caused the placeholder (Alaska content copied) content to show on the page.

[:sunglasses: PREVIEW](https://federalist-65bb532b-030a-4b62-a416-d7b74e4c0f2a.app.cloud.gov/preview/18f/portfolios/unlink-vermont/state-local/)

Changes proposed in this pull request:
- remove link to Vermont page by using the include file `card-project-nolink.html` until the Vermont-specific content can be added. 

