### PR TITLE
patch button hover colors on .usa-dark-background

### DIFF
--- a/_sass/custom/_overrides/portfolio-page.scss
+++ b/_sass/custom/_overrides/portfolio-page.scss
@@ -7,6 +7,11 @@ a.usa-button.usa-button-secondary {
   box-shadow: unset;
 }
 
+.usa-dark-background .usa-button--accent-cool:hover, .usa-button--accent-cool.usa-button--hover {
+  color: #1b1b1b;
+  background-color: #28a0cb;
+}
+
 img.home-cta-icon {
   width: 7rem;
   margin: 0 3rem 1rem 0;


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>

Fixes issue(s) #51.

[:sunglasses: PREVIEW](https://federalist-65bb532b-030a-4b62-a416-d7b74e4c0f2a.app.cloud.gov/preview/18f/portfolios/patch-usa-dark-bkg-hover/)

[Preview README for this branch](https://github.com/18F/portfolios/blob/BRANCH_NAME/README.md)

Changes proposed in this pull request:
- add more specific CSS in the _overrides SCSS file to help the `button`:hover state match the others when `.usa-dark-background` class is applied to its container

/cc @stvnrlly 
