### PR TITLE
Change sans fontstack to helvetica

### DIFF
--- a/_sass/settings/_uswds-theme-typography.scss
+++ b/_sass/settings/_uswds-theme-typography.scss
@@ -167,7 +167,7 @@ $theme-font-type-lang: false;
 $theme-font-type-mono: "roboto-mono";
 
 // sans-serif
-$theme-font-type-sans: "public-sans";
+$theme-font-type-sans: "helvetica";
 
 // serif
 $theme-font-type-serif: "merriweather";


### PR DESCRIPTION
Addresses issue(s) #47, updating the font stack to helvetica in order to match the 18F brand. 

[👓 : Preview](https://federalist-65bb532b-030a-4b62-a416-d7b74e4c0f2a.app.cloud.gov/preview/18f/portfolios/update-typestack/)


/cc @Jacklynn and @stvnrlly 
