### PR TITLE
update agency_subset alt, resolves #56

### DIFF
--- a/_includes/agency_subset.html
+++ b/_includes/agency_subset.html
@@ -13,7 +13,7 @@
               <img
                 class="list-images-image"
                 src="{{ partner.logo | prepend: site.baseurl }}"
-                alt="{{ partner.logo }} logo"
+                alt=""
               />
               {% if partner.agency_url %}
               <a


### PR DESCRIPTION
Signed-off-by: Robert Jolly <robert.jolly@gsa.gov>

Fixes issue(s) #56

[![CircleCI](https://circleci.com/gh/18F/portfolios/tree/patch-agencies-alt.svg?style=svg)](https://circleci.com/gh/18F/portfolios/tree/patch-agencies-alt)

[:sunglasses: PREVIEW](https://federalist-65bb532b-030a-4b62-a416-d7b74e4c0f2a.app.cloud.gov/preview/18f/portfolios/patch-agencies-alt/)

Changes proposed in this pull request:
- Remove `alt` content that wasn't great, use empty `alt` instead since the logos are decorative
